### PR TITLE
Update SamuraiRotation.cs - Removed ModifyTengetsuPvE

### DIFF
--- a/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
+++ b/RotationSolver.Basic/Rotations/Basic/SamuraiRotation.cs
@@ -68,11 +68,6 @@ partial class SamuraiRotation
     //     setting.ActionCheck = () => MeditationStacks == 3;
     // }
     
-    static partial void ModifyThirdEyePvE(ref ActionSetting setting)
-    {
-        setting.ComboIds = [ActionID.TengetsuPvE];
-    }
-    
     static partial void ModifyJinpuPvE(ref ActionSetting setting)
     {
         setting.ComboIds = [ActionID.HakazePvE, ActionID.GyofuPvE];


### PR DESCRIPTION
Removing this line of code since Tengetsu works if you add it directly to a rotation.